### PR TITLE
Update revision, publish to maven central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,4 +15,5 @@ jobs:
     uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
     with:
       publishToBinaries: true
+      mavenCentralSync: true
       slackChannel:  squad-web

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <inceptionYear>2025</inceptionYear>
 
     <properties>
-        <revision>1.0.0-SNAPSHOT</revision>
+        <revision>1.3.0-SNAPSHOT</revision>
         <maven-plugin-tools.version>3.15.1</maven-plugin-tools.version>
         <mavenVersion>3.8.1</mavenVersion>
         <gitRepositoryName>rspec-maven-plugin</gitRepositoryName>


### PR DESCRIPTION
I'm failing now the build_win task when searching for the rspec-maven-plugin - https://cirrus-ci.com/task/6504980774912000

Not sure if this is due to the artifact or populating it from the populate-script and instead of as a byproduct of the regular build process.