### PR TITLE
BUILD-10765 Update gh-action_release to v6.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@7b055eca5ce771ff254fbec2697c0fc1c7207e1e # 6.4.0
     with:
       publishToBinaries: true
       slackChannel: ask-squad-web


### PR DESCRIPTION
## Summary
- Update `gh-action_release` to v6.4.0 (`7b055eca5ce771ff254fbec2697c0fc1c7207e1e`)

See: https://discuss.sonarsource.com/t/action-required-update-your-github-actions-cache-release-and-releasability-before-16-03/23899

## Test plan
- [ ] Verify release workflow runs successfully