### PR TITLE
BUILD-10765 Important: Update SonarSource/gh-action_release to 6.5.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@9c99807e01ae0fdf4e94e96d5e521648e91031b6 # 6.4.1
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@c52861bb0e5dd564187f3fd74e048f20aef0f761 # 6.5.0
     with:
       publishToBinaries: true
       slackChannel: ask-squad-web


### PR DESCRIPTION
**Important:** Update `SonarSource/gh-action_release` to `c52861bb0e5dd564187f3fd74e048f20aef0f761` (6.5.0) for compliance with allowed versions.

See: https://discuss.sonarsource.com/t/action-required-update-your-github-actions-cache-release-and-releasability-before-10-04/23899/5