### PR TITLE
JS-1602 Disable Renovate grouping and create PRs immediately

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,10 +8,13 @@
   },
   "packageRules": [
     {
+      "description": "Don't group updates by default",
+      "matchPackageNames": ["*"],
+      "groupName": null
+    },
+    {
       "matchManagers": ["github-actions"],
-      "pinDigests": false,
-      "groupName": "all github actions",
-      "groupSlug": "all-github-actions"
+      "pinDigests": false
     },
     {
       "matchManagers": ["github-actions"],
@@ -24,5 +27,6 @@
     }
   ],
   "autoApprove": true,
+  "prCreation": "immediate",
   "rebaseWhen": "never"
 }


### PR DESCRIPTION
## Summary
- add a default Renovate package rule to disable grouping (groupName: null)
- keep GitHub Actions digest behavior without forcing grouped action updates
- set prCreation to immediate

This mirrors the same Renovate adjustment already applied in sonar-flex so dependency updates are not delayed by grouped scheduling.