### PR TITLE
JS-1874 Update sonar-rule-api to 2.22.0 and wire GitHub token support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.sonarsource.rule-api</groupId>
             <artifactId>rule-api</artifactId>
-            <version>2.21.0.5887</version>
+            <version>2.22.0.5927</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/application/ApplicationRuleRepository.java
+++ b/src/main/java/application/ApplicationRuleRepository.java
@@ -25,8 +25,8 @@ public class ApplicationRuleRepository implements domain.RuleRepository {
 
   private final GitHubRuleMaker ruleMaker;
 
-  public ApplicationRuleRepository(String branchName) {
-    this.ruleMaker = GitHubRuleMaker.create(branchName);
+  public ApplicationRuleRepository(String branchName, String githubToken) {
+    this.ruleMaker = GitHubRuleMaker.create(branchName, githubToken);
   }
 
   public List<RuleFiles> getRuleManifestsByRuleSubdirectory(String ruleSubdirectory) {

--- a/src/main/java/application/GenerateRegistrarsMojo.java
+++ b/src/main/java/application/GenerateRegistrarsMojo.java
@@ -36,6 +36,13 @@ public class GenerateRegistrarsMojo extends AbstractMojo {
   @Parameter(defaultValue = "master")
   private String vcsBranchName;
 
+  /**
+   * Optional GitHub token used to access the private RSPEC repository.
+   * When omitted, sonar-rule-api falls back to GITHUB_TOKEN and then to the gh auth token command.
+   */
+  @Parameter(property = "githubToken")
+  private String githubToken;
+
   @Parameter(defaultValue = "Sonar way")
   private String profileName;
 
@@ -56,7 +63,7 @@ public class GenerateRegistrarsMojo extends AbstractMojo {
     try {
       var generator = new RegistrarsGenerator(
         logger::info,
-        new ApplicationRuleRepository(this.vcsBranchName),
+        new ApplicationRuleRepository(this.vcsBranchName, this.githubToken),
         new ApplicationFileSystem(host)
       );
 

--- a/src/main/java/application/GenerateRuleDataMojo.java
+++ b/src/main/java/application/GenerateRuleDataMojo.java
@@ -36,6 +36,13 @@ public class GenerateRuleDataMojo extends AbstractMojo {
   @Parameter(defaultValue = "master")
   private String vcsBranchName;
 
+  /**
+   * Optional GitHub token used to access the private RSPEC repository.
+   * When omitted, sonar-rule-api falls back to GITHUB_TOKEN and then to the gh auth token command.
+   */
+  @Parameter(property = "githubToken")
+  private String githubToken;
+
   @Override
   public void execute() throws MojoExecutionException {
     var host = new JVMHost();
@@ -44,7 +51,7 @@ public class GenerateRuleDataMojo extends AbstractMojo {
     try {
       var generator = new RuleDataGenerator(
         logger::info,
-        new ApplicationRuleRepository(this.vcsBranchName),
+        new ApplicationRuleRepository(this.vcsBranchName, this.githubToken),
         new ApplicationFileSystem(host)
       );
 


### PR DESCRIPTION
## Summary
- update `com.sonarsource.rule-api:rule-api` to `2.22.0.5927`
- expose an optional `githubToken` mojo parameter on both goals
- pass the explicit token through to `GitHubRuleMaker.create(branch, token)` so the plugin can use the new token resolution flow

## Verification
- `mvn verify`