### PR TITLE
JS-1891 Pass RSPEC SHA to rule API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ builds to use a previous RSPEC revision when the current RSPEC state is not desi
 
 ```xml
 <configuration>
-    <vcsBranchName>dogfood-automerge</vcsBranchName>
     <rspecSha>0123456789abcdef0123456789abcdef01234567</rspecSha>
 </configuration>
 ```
 
 It can also be provided from the command line with `-Drspec.sha=<commit-sha>`.
-When `rspec.sha` is set, it takes precedence over `vcsBranchName`.
+Do not set `rspecSha` together with `vcsBranchName`: use `rspecSha` for a fixed revision or `vcsBranchName` for a
+branch.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # rspec-maven-plugin
 
 RSPEC Maven Plugin Project
+
+Set `rspec.sha` to pin generated data to a specific RSPEC commit. This makes generated data reproducible and allows
+builds to use a previous RSPEC revision when the current RSPEC state is not desired.
+
+```xml
+<configuration>
+    <vcsBranchName>dogfood-automerge</vcsBranchName>
+    <rspecSha>0123456789abcdef0123456789abcdef01234567</rspecSha>
+</configuration>
+```
+
+It can also be provided from the command line with `-Drspec.sha=<commit-sha>`.
+When `rspec.sha` is set, it takes precedence over `vcsBranchName`.

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.sonarsource.rule-api</groupId>
             <artifactId>rule-api</artifactId>
-            <version>2.23.0.5933</version>
+            <version>2.24.0.5949</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/application/ApplicationRuleRepository.java
+++ b/src/main/java/application/ApplicationRuleRepository.java
@@ -23,21 +23,50 @@ import java.util.List;
 
 public class ApplicationRuleRepository implements domain.RuleRepository {
 
+  private static final String DEFAULT_BRANCH_NAME = "master";
+  private static final String BRANCH_AND_SHA_ERROR_MESSAGE = "Use either vcsBranchName or rspecSha, not both.";
+
   private final GitHubRuleMaker ruleMaker;
 
-  public ApplicationRuleRepository(String branchName, String githubToken) {
-    this(branchName, githubToken, null);
+  public static ApplicationRuleRepository create(String branchName, String githubToken) {
+    var normalizedBranchName = normalize(branchName);
+    return new ApplicationRuleRepository(
+      GitHubRuleMaker.create(normalizedBranchName == null ? DEFAULT_BRANCH_NAME : normalizedBranchName, githubToken)
+    );
   }
 
-  public ApplicationRuleRepository(String branchName, String githubToken, String rspecSha) {
-    this.ruleMaker = createRuleMaker(branchName, githubToken, rspecSha);
-  }
-
-  private static GitHubRuleMaker createRuleMaker(String branchName, String githubToken, String rspecSha) {
-    if (rspecSha == null || rspecSha.isBlank()) {
-      return GitHubRuleMaker.create(branchName, githubToken);
+  public static ApplicationRuleRepository createAtRevision(String rspecSha, String githubToken) {
+    var normalizedRspecSha = normalize(rspecSha);
+    if (normalizedRspecSha == null) {
+      throw new IllegalArgumentException("rspecSha must not be blank.");
     }
-    return GitHubRuleMaker.createAtRevision(rspecSha.trim(), githubToken);
+    return new ApplicationRuleRepository(
+      GitHubRuleMaker.createAtRevision(normalizedRspecSha, githubToken)
+    );
+  }
+
+  static ApplicationRuleRepository createFromConfiguration(String branchName, String githubToken, String rspecSha) {
+    var normalizedBranchName = normalize(branchName);
+    var normalizedRspecSha = normalize(rspecSha);
+
+    if (normalizedRspecSha == null) {
+      return create(normalizedBranchName, githubToken);
+    }
+    if (normalizedBranchName != null) {
+      throw new IllegalArgumentException(BRANCH_AND_SHA_ERROR_MESSAGE);
+    }
+    return createAtRevision(normalizedRspecSha, githubToken);
+  }
+
+  private ApplicationRuleRepository(GitHubRuleMaker ruleMaker) {
+    this.ruleMaker = ruleMaker;
+  }
+
+  private static String normalize(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    return value.trim();
   }
 
   public List<RuleFiles> getRuleManifestsByRuleSubdirectory(String ruleSubdirectory) {

--- a/src/main/java/application/ApplicationRuleRepository.java
+++ b/src/main/java/application/ApplicationRuleRepository.java
@@ -26,7 +26,18 @@ public class ApplicationRuleRepository implements domain.RuleRepository {
   private final GitHubRuleMaker ruleMaker;
 
   public ApplicationRuleRepository(String branchName, String githubToken) {
-    this.ruleMaker = GitHubRuleMaker.create(branchName, githubToken);
+    this(branchName, githubToken, null);
+  }
+
+  public ApplicationRuleRepository(String branchName, String githubToken, String rspecSha) {
+    this.ruleMaker = createRuleMaker(branchName, githubToken, rspecSha);
+  }
+
+  private static GitHubRuleMaker createRuleMaker(String branchName, String githubToken, String rspecSha) {
+    if (rspecSha == null || rspecSha.isBlank()) {
+      return GitHubRuleMaker.create(branchName, githubToken);
+    }
+    return GitHubRuleMaker.createAtRevision(rspecSha.trim(), githubToken);
   }
 
   public List<RuleFiles> getRuleManifestsByRuleSubdirectory(String ruleSubdirectory) {

--- a/src/main/java/application/GenerateRegistrarsMojo.java
+++ b/src/main/java/application/GenerateRegistrarsMojo.java
@@ -43,6 +43,12 @@ public class GenerateRegistrarsMojo extends AbstractMojo {
   @Parameter(property = "githubToken")
   private String githubToken;
 
+  /**
+   * Optional RSPEC commit SHA used to pin registrar generation.
+   */
+  @Parameter(property = "rspec.sha")
+  private String rspecSha;
+
   @Parameter(defaultValue = "Sonar way")
   private String profileName;
 
@@ -63,7 +69,7 @@ public class GenerateRegistrarsMojo extends AbstractMojo {
     try {
       var generator = new RegistrarsGenerator(
         logger::info,
-        new ApplicationRuleRepository(this.vcsBranchName, this.githubToken),
+        new ApplicationRuleRepository(this.vcsBranchName, this.githubToken, this.rspecSha),
         new ApplicationFileSystem(host)
       );
 

--- a/src/main/java/application/GenerateRegistrarsMojo.java
+++ b/src/main/java/application/GenerateRegistrarsMojo.java
@@ -33,7 +33,10 @@ public class GenerateRegistrarsMojo extends AbstractMojo {
   @Parameter(required = true)
   private String targetDirectory;
 
-  @Parameter(defaultValue = "master")
+  /**
+   * Optional RSPEC branch name. When omitted, the plugin uses master unless rspecSha is set.
+   */
+  @Parameter
   private String vcsBranchName;
 
   /**
@@ -69,7 +72,11 @@ public class GenerateRegistrarsMojo extends AbstractMojo {
     try {
       var generator = new RegistrarsGenerator(
         logger::info,
-        new ApplicationRuleRepository(this.vcsBranchName, this.githubToken, this.rspecSha),
+        ApplicationRuleRepository.createFromConfiguration(
+          this.vcsBranchName,
+          this.githubToken,
+          this.rspecSha
+        ),
         new ApplicationFileSystem(host)
       );
 
@@ -81,6 +88,8 @@ public class GenerateRegistrarsMojo extends AbstractMojo {
         this.targetDirectory,
         this.profileName
       );
+    } catch (IllegalArgumentException e) {
+      throw new MojoExecutionException(e.getMessage(), e);
     } catch (Exception e) {
       throw new MojoExecutionException(e);
     }

--- a/src/main/java/application/GenerateRuleDataMojo.java
+++ b/src/main/java/application/GenerateRuleDataMojo.java
@@ -43,6 +43,12 @@ public class GenerateRuleDataMojo extends AbstractMojo {
   @Parameter(property = "githubToken")
   private String githubToken;
 
+  /**
+   * Optional RSPEC commit SHA used to pin rule data generation.
+   */
+  @Parameter(property = "rspec.sha")
+  private String rspecSha;
+
   @Override
   public void execute() throws MojoExecutionException {
     var host = new JVMHost();
@@ -51,7 +57,7 @@ public class GenerateRuleDataMojo extends AbstractMojo {
     try {
       var generator = new RuleDataGenerator(
         logger::info,
-        new ApplicationRuleRepository(this.vcsBranchName, this.githubToken),
+        new ApplicationRuleRepository(this.vcsBranchName, this.githubToken, this.rspecSha),
         new ApplicationFileSystem(host)
       );
 

--- a/src/main/java/application/GenerateRuleDataMojo.java
+++ b/src/main/java/application/GenerateRuleDataMojo.java
@@ -33,7 +33,10 @@ public class GenerateRuleDataMojo extends AbstractMojo {
   @Parameter(required = true)
   private String targetDirectory;
 
-  @Parameter(defaultValue = "master")
+  /**
+   * Optional RSPEC branch name. When omitted, the plugin uses master unless rspecSha is set.
+   */
+  @Parameter
   private String vcsBranchName;
 
   /**
@@ -57,11 +60,17 @@ public class GenerateRuleDataMojo extends AbstractMojo {
     try {
       var generator = new RuleDataGenerator(
         logger::info,
-        new ApplicationRuleRepository(this.vcsBranchName, this.githubToken, this.rspecSha),
+        ApplicationRuleRepository.createFromConfiguration(
+          this.vcsBranchName,
+          this.githubToken,
+          this.rspecSha
+        ),
         new ApplicationFileSystem(host)
       );
 
       generator.execute(this.ruleSubdirectory, this.targetDirectory);
+    } catch (IllegalArgumentException e) {
+      throw new MojoExecutionException(e.getMessage(), e);
     } catch (Exception e) {
       throw new MojoExecutionException(e);
     }


### PR DESCRIPTION
## Summary
- consume the promoted `com.sonarsource.rule-api:rule-api:2.24.0.5949` artifact from merged SonarSource/sonar-rule-api#306
- add an optional `rspec.sha` Maven property to `generate-rule-data` and `generate-registrars`
- pass the SHA through with `GitHubRuleMaker.createAtRevision(...)` so generated rule data can be pinned to an exact RSPEC commit
- document that `rspec.sha` supports reproducible builds and allows generation from a prior RSPEC revision

## Testing
- `mvn -q -DskipTests package`
- `mvn -q test`