### PR TITLE
JS-1895 Fix release workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,19 @@
 ---
 name: sonar-release
-# This workflow is triggered when publishing a new github release
+# This workflow is triggered manually with the full release version.
 # yamllint disable-line rule:truthy
 on:
-  release:
-    types:
-      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Full version including build number, e.g. 1.4.0.120
+        required: true
+        type: string
+      dryRun:
+        description: Flag to enable the dry-run execution
+        default: false
+        required: false
+        type: boolean
 
 jobs:
   release:
@@ -14,5 +22,7 @@ jobs:
       contents: write
     uses: SonarSource/gh-action_release/.github/workflows/main.yaml@4417d62d874a2a2fcac6e4bc5bec9a7f93e18cd1 # 7.3.0
     with:
+      version: ${{ inputs.version }}
       publishToBinaries: true
       slackChannel: ask-squad-web
+      dryRun: ${{ inputs.dryRun == true }}


### PR DESCRIPTION
## Summary

The release workflow was still using the old `release: published` trigger while calling `gh-action_release` v7.3.0. The reusable v7 workflow requires a `version` input and uses the draft-first release flow, so the release run failed during workflow startup before any job was created.

This updates `.github/workflows/release.yml` to the v7 shape:

- use `workflow_dispatch` with required `version`
- pass `version` through to `gh-action_release`
- expose a `dryRun` input

## Verification

- Parsed `.github/workflows/release.yml` with Ruby YAML parser
- `git diff --check`

## Release recovery note

The failed `1.4.0.120` run was triggered from an already-published GitHub release. With `gh-action_release` v7, retrying should be done from Actions with a draft release. The existing published release/tag may need to be cleaned up or a fresh build/version used before retrying.