### PR TITLE
CLP-21 Move repository ownership to Core Languages and Parsers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-* @sonarsource/quality-web-squad
+.github/CODEOWNERS @SonarSource/code-quality-core-languages-parsers-squad


### PR DESCRIPTION
----
## Summary by Gitar

- **Repository management:**
  - Updated `.github/CODEOWNERS` to transition ownership to the Core Languages and Parsers squad.

<sub>This will update automatically on new commits.</sub>